### PR TITLE
Code samples use explicit example variables

### DIFF
--- a/src/pages/docs_sdk_delete-item.html
+++ b/src/pages/docs_sdk_delete-item.html
@@ -5,11 +5,14 @@
   <p><span class="font-semibold">deleteItem</span> lets you delete an item from a user's database. This API will return a promise that gets resolved once the item has been durably deleted from the database.</p>
 
   <pre>
-    <code class="language-javascript">userbase.deleteItem({ databaseName, itemId })
-      .then(() => {
+    <code class="language-javascript">
+      userbase.deleteItem({
+        databaseName: 'example-database-name',
+        itemId: '0001' 
+      }).then(() => {
         // item deleted
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_delete-user.html
+++ b/src/pages/docs_sdk_delete-user.html
@@ -5,8 +5,11 @@
   <p><span class="font-semibold">deleteUser</span> lets you delete the logged in user and all its data. This API will return a promise that gets resolved once the user gets marked for deletion. It will also automatically invalidate the user's session and log out the user.</p>
 
   <pre>
-    <code class="language-javascript">userbase.deleteUser()
-      .catch((e) => console.error(e))</code>
+    <code class="language-javascript">
+      userbase.deleteUser().then(() => {
+        // user marked for deletion
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="errors">Errors</h3>

--- a/src/pages/docs_sdk_forgot-password.html
+++ b/src/pages/docs_sdk_forgot-password.html
@@ -5,11 +5,13 @@
   <p><span class="font-semibold">forgotPassword</span> lets you send a temporary password to the user's email address. This API will return a promise that gets resolved once the email with the temporary password has been sent.</p>
 
   <pre>
-    <code class="language-javascript">userbase.forgotPassword({ username })
-      .then((user) => {
+    <code class="language-javascript">
+      userbase.forgotPassword({
+        username: 'example-username'
+      }).then((user) => {
         // email with temporary password sent
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_init.html
+++ b/src/pages/docs_sdk_init.html
@@ -5,16 +5,17 @@
   <p><span class="font-semibold">init</span> needs to be the very first thing you call in your web app. It initializes the SDK with your App ID, and it also handles automatic logins when users return to your web app with an active session.</p>
 
   <pre>
-    <code class="language-javascript">userbase.init({ appId })
-      .then((session) => {
+    <code class="language-javascript">
+      userbase.init({
+        appId: 'YOUR_APP_ID'
+      }).then((session) => {
         // SDK initialized successfully
         
         if (session.user) {
           // there is a valid active session
           console.log(session.user.username)
         }
-      })
-      .catch((e) => console.error(e))
+      }).catch((e) => console.error(e))
     </code>
   </pre>
 

--- a/src/pages/docs_sdk_insert-item.html
+++ b/src/pages/docs_sdk_insert-item.html
@@ -21,7 +21,7 @@
       <span class="field">databaseName</span> [string | Len: 1-50] - The database name to use.
     </li>
     <li>
-      <span class="field">item</span> [object | Max size: 10&nbsp;KB] - The item to insert.
+      <span class="field">item</span> [object | string | number | boolean | null | Max size: 10&nbsp;KB] - The item to insert.
     </li>
     <li>
       <span class="field">itemId</span> [string | Len: 1-100 | optional] - The item's unique identifier.

--- a/src/pages/docs_sdk_insert-item.html
+++ b/src/pages/docs_sdk_insert-item.html
@@ -5,11 +5,13 @@
   <p><span class="font-semibold">insertItem</span> lets you add items to a user's database. This API will return a promise that gets resolved once the item has been durably inserted into the database.</p>
 
   <pre>
-    <code class="language-javascript">userbase.insertItem({ databaseName, item, itemId })
-      .then(() => {
+    <code class="language-javascript">
+      userbase.insertItem({
+        databaseName: 'example-database-name',
+        item: { example: 'Sample Item A' }
+      }).then(() => {
         // item inserted
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))</code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_open-database.html
+++ b/src/pages/docs_sdk_open-database.html
@@ -5,11 +5,16 @@
   <p><span class="font-semibold">openDatabase</span> lets you retrieve your user's data. You also need to have a database open before storing or modifying user data. This API will return a promise that gets resolved once the database becomes available for use.</p>
 
   <pre>
-    <code class="language-javascript">userbase.openDatabase({ databaseName, changeHandler })
-      .then(() => {
+    <code class="language-javascript">
+      userbase.openDatabase({
+        databaseName: 'example-database-name',
+        changeHandler: function (items) {
+          // update your application state with the database items
+        }
+      }).then(() => {
         // the database can now be used
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_put-transaction.html
+++ b/src/pages/docs_sdk_put-transaction.html
@@ -6,17 +6,16 @@
 
   <pre>
     <code class="language-javascript">
-    const operations = [
-      { command: 'Update', item: { todo: 'Item A' } },
-      { command: 'Insert', item: { todo: 'Item B' }, itemId: '0002' },
-      { command: 'Delete', itemId: '0003' }
-    ]
-
-    userbase.putTransaction({ databaseName, operations })
-      .then(() => {
-        // transaction applied
-      })
-      .catch((e) => console.error(e))
+    userbase.putTransaction({
+      databaseName: 'example-database-name',
+      operations: [
+        { command: 'Insert', item: { example: 'Sample Item A' } },
+        { command: 'Update', item: { example: 'Sample Item B' }, itemId: '0002' },
+        { command: 'Delete', itemId: '0003' }
+      ]
+    }).then(() => {
+      // transaction applied
+    }).catch((e) => console.error(e))
     </code>
   </pre>
 

--- a/src/pages/docs_sdk_sign-in.html
+++ b/src/pages/docs_sdk_sign-in.html
@@ -5,11 +5,14 @@
   <p><span class="font-semibold">signIn</span> lets your users log into your web app. This API will return a promise that gets resolved once the user has been logged in.</p>
 
   <pre>
-    <code class="language-javascript">userbase.signIn({ username, password, rememberMe: 'session' })
-      .then((user) => {
+    <code class="language-javascript">
+      userbase.signIn({
+        username: 'example-username',
+        password: 'example-password'
+      }).then((user) => {
         // user logged in
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_sign-out.html
+++ b/src/pages/docs_sdk_sign-out.html
@@ -5,11 +5,11 @@
   <p><span class="font-semibold">signOut</span> lets your users log out of your web app. This API will return a promise that gets resolved once the user has been logged out.</p>
 
   <pre>
-    <code class="language-javascript">userbase.signOut()
-      .then(() => {
+    <code class="language-javascript">
+      userbase.signOut().then(() => {
         // user logged out
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="errors">Errors</h3>

--- a/src/pages/docs_sdk_sign-up.html
+++ b/src/pages/docs_sdk_sign-up.html
@@ -5,11 +5,14 @@
   <p><span class="font-semibold">signUp</span> lets you create user accounts for your web app. This API will return a promise that gets resolved once the user account has been created.</p>
 
   <pre>
-    <code class="language-javascript">userbase.signUp({ username, password, email, profile, rememberMe: 'session' })
-      .then((user) => {
+    <code class="language-javascript">
+      userbase.signUp({
+        username: 'example-username',
+        password: 'example-password'
+      }).then((user) => {
         // user account created
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_update-item.html
+++ b/src/pages/docs_sdk_update-item.html
@@ -23,7 +23,7 @@
       <span class="field">databaseName</span> [string | Len: 1-50] - The database name to use.
     </li>
     <li>
-      <span class="field">item</span> [object | Max size: 10&nbsp;KB] - The object to overwrite the existing item with.
+      <span class="field">item</span> [object | string | number | boolean | null | Max size: 10&nbsp;KB] - The object to overwrite the existing item with.
     </li>
     <li>
       <span class="field">itemId</span> [string | Len: 1-100] - The unique identifier of the item to replace.

--- a/src/pages/docs_sdk_update-item.html
+++ b/src/pages/docs_sdk_update-item.html
@@ -5,11 +5,15 @@
   <p><span class="font-semibold">updateItem</span> lets you modify an existing item in a user's database. This API will return a promise that gets resolved once the item has been durably updated in the database.</p>
 
   <pre>
-    <code class="language-javascript">userbase.updateItem({ databaseName, item, itemId })
-      .then(() => {
+    <code class="language-javascript">
+      userbase.updateItem({
+        databaseName: 'example-database-name',
+        item: { example: 'Updated Sample Item A' },
+        itemId: '0001'
+      }).then(() => {
         // item updated
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>

--- a/src/pages/docs_sdk_update-user.html
+++ b/src/pages/docs_sdk_update-user.html
@@ -5,30 +5,36 @@
   <p><span class="font-semibold">updateUser</span> lets you update a user's account. This API will return a promise that gets resolved once the user account has been updated.</p>
 
   <pre>
-    <code class="language-javascript">userbase.updateUser({ username, currentPassword, newPassword, email, profile })
-      .then(() => {
+    <code class="language-javascript">
+      userbase.updateUser({
+        username: 'example-new-username',
+        currentPassword: 'example-password',
+        newPassword: 'example-new-password',
+        email: 'example@email.com', 
+        profile: { example: 'value' }
+      }).then(() => {
         // user account updated
-      })
-      .catch((e) => console.error(e))</code>
+      }).catch((e) => console.error(e))
+    </code>
   </pre>
 
   <h3 id="params">Parameters</h3>
 
   <ul>
     <li>
-      <span class="field">username</span> [string | Len: 1-100] - The new username for the account.
+      <span class="field">username</span> [string | Len: 1-100 | optional] - The new username for the account.
     </li>
     <li>
-      <span class="field">currentPassword</span> [string | Len: 6-1000] - The current password for the account. Required if newPassword provided.
+      <span class="field">currentPassword</span> [string | Len: 6-1000 | optional] - The current password for the account. Required if newPassword provided.
     </li>
     <li>
-      <span class="field">newPassword</span> [string | Len: 6-1000] - The new password for the account.
+      <span class="field">newPassword</span> [string | Len: 6-1000 | optional] - The new password for the account.
     </li>
     <li>
-      <span class="field">email</span> [string | null | undefined | false] - The new email for the account. If explicitly set to a falsey value, deletes the user's email.
+      <span class="field">email</span> [string | null | undefined | false | optional] - The new email for the account. If explicitly set to a falsey value, deletes the user's email.
     </li>
     <li>
-      <span class="field">profile</span> [object | null | undefined | false | Key Len: 1-20 | Val Len: 1-1000 | Keys: 1-100] - The new profile for the account. All keys and values must be strings. If explicitly set to a falsey value, deletes the user's profile.
+      <span class="field">profile</span> [object | null | undefined | false | Key Len: 1-20 | Val Len: 1-1000 | Keys: 1-100 | optional] - The new profile for the account. All keys and values must be strings. If explicitly set to a falsey value, deletes the user's profile.
     </li>
   </ul>
 


### PR DESCRIPTION
- Updated code samples to use explicit example variables as per [feedback](https://github.com/encrypted-dev/userbase/issues/124) from @gduverger. Thank you Georges!
- Removed optional parameters in code samples (except in `updateUser` because they're all optional)
- Updated `insertItem` and `updateItem` to allow items of type string, number, boolean, and null (and not just object).